### PR TITLE
mex-model 2.1.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,35 @@
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+share/python-wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+MANIFEST
 
+# Environments
+*.env
+.env
+
+# MacOS
 .DS_Store
+
+# PyCharm
+.idea/
+.idea_modules/
+
+# VisualStudioCode
+.vscode/*
+.history/
+*.code-workspace

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ default_language_version:
 files: schema
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: pretty-format-json
         args: [--autofix, --no-sort-keys, --indent=4, --no-ensure-ascii]

--- a/schema/entities/access-platform.json
+++ b/schema/entities/access-platform.json
@@ -97,12 +97,12 @@
         "technicalAccessibility": {
             "$ref": "/schema/entities/concept#/identifier",
             "examples": [
-                "https://mex.rki.de/concept/technical-accessibility-1"
+                "https://mex.rki.de/item/technical-accessibility-1"
             ],
             "subPropertyOf": [
                 "http://purl.org/dc/terms/type"
             ],
-            "useScheme": "https://mex.rki.de/item/technical-accessbility"
+            "useScheme": "https://mex.rki.de/item/technical-accessibility"
         },
         "title": {
             "items": {

--- a/schema/entities/activity.json
+++ b/schema/entities/activity.json
@@ -63,17 +63,20 @@
             "type": "array"
         },
         "end": {
+            "items": {
+                "format": "date",
+                "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
+                "type": "string"
+            },
             "examples": [
                 "2024-01-17",
                 "2024",
                 "2024-01"
             ],
-            "format": "date",
-            "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
             "sameAs": [
                 "http://www.wikidata.org/entity/P582"
             ],
-            "type": "string"
+            "type": "array"
         },
         "externalAssociate": {
             "items": {
@@ -183,17 +186,20 @@
             "$ref": "/schema/fields/identifier"
         },
         "start": {
+            "items": {
+                "format": "date",
+                "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
+                "type": "string"
+            },
             "examples": [
                 "2023-01-16",
                 "2023",
                 "2023-02"
             ],
-            "format": "date",
-            "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
             "sameAs": [
                 "http://www.wikidata.org/entity/P580"
             ],
-            "type": "string"
+            "type": "array"
         },
         "succeeds": {
             "items": {

--- a/schema/entities/contact-point.json
+++ b/schema/entities/contact-point.json
@@ -8,7 +8,7 @@
                     "info@rki.de"
                 ],
                 "format": "email",
-                "pattern": "^[^@ \t\r\n]+@[^@ \t\r\n]+\\.[^@ \t\r\n]+$",
+                "pattern": "^[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+$",
                 "type": "string"
             },
             "minItems": 1,

--- a/schema/entities/distribution.json
+++ b/schema/entities/distribution.json
@@ -91,18 +91,20 @@
             "anyOf": [
                 {
                     "format": "date-time",
-                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+                    "type": "string"
                 },
                 {
                     "format": "date",
-                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$"
+                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
+                    "type": "string"
                 }
             ],
             "examples": [
-                "2023-01-16",
-                "2023",
-                "2023-02",
-                "2020-04-03T08:58:26Z"
+                "2011",
+                "2019-03",
+                "2014-08-24",
+                "2022-09-30T20:48:35Z"
             ],
             "sameAs": [
                 "http://purl.org/dc/terms/issued"
@@ -111,9 +113,13 @@
         },
         "license": {
             "$ref": "/schema/entities/concept#/identifier",
+            "examples": [
+                "https://mex.rki.de/item/license-1"
+            ],
             "sameAs": [
                 "http://purl.org/dc/terms/license"
-            ]
+            ],
+            "useScheme": "https://mex.rki.de/item/license"
         },
         "mediaType": {
             "$ref": "/schema/entities/concept#/identifier",
@@ -130,18 +136,20 @@
             "anyOf": [
                 {
                     "format": "date-time",
-                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+                    "type": "string"
                 },
                 {
                     "format": "date",
-                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$"
+                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
+                    "type": "string"
                 }
             ],
             "examples": [
-                "2023-01-16",
-                "2023",
-                "2023-02",
-                "2020-04-03T08:58:26Z"
+                "2011",
+                "2019-03",
+                "2014-08-24",
+                "2022-09-30T20:48:35Z"
             ],
             "sameAs": [
                 "http://purl.org/dc/terms/modified"

--- a/schema/entities/organizational-unit.json
+++ b/schema/entities/organizational-unit.json
@@ -17,7 +17,7 @@
                     "info@rki.de"
                 ],
                 "format": "email",
-                "pattern": "^[^@ \t\r\n]+@[^@ \t\r\n]+\\.[^@ \t\r\n]+$",
+                "pattern": "^[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+$",
                 "type": "string"
             },
             "sameAs": [

--- a/schema/entities/person.json
+++ b/schema/entities/person.json
@@ -18,7 +18,7 @@
                     "info@rki.de"
                 ],
                 "format": "email",
-                "pattern": "^[^@ \t\r\n]+@[^@ \t\r\n]+\\.[^@ \t\r\n]+$",
+                "pattern": "^[^@ \\t\\r\\n]+@[^@ \\t\\r\\n]+\\.[^@ \\t\\r\\n]+$",
                 "type": "string"
             },
             "sameAs": [
@@ -29,9 +29,9 @@
         },
         "familyName": {
             "examples": [
-                "Schmidt",
-                "Meier",
-                "Schmidt-Meier"
+                "Patapoutian",
+                "Skłodowska-Curie",
+                "Muta Maathai"
             ],
             "items": {
                 "type": "string"
@@ -44,9 +44,9 @@
         },
         "fullName": {
             "examples": [
-                "Anna Schmidt",
-                "P. Meier",
-                "Wolf Maria Hermann"
+                "Juturna Felicitás",
+                "M. Berhanu",
+                "Keone Seong-Hyeon"
             ],
             "items": {
                 "type": "string"
@@ -58,8 +58,9 @@
         },
         "givenName": {
             "examples": [
-                "Thomas",
-                "Anna"
+                "Romāns",
+                "Marie Salomea",
+                "May-Britt"
             ],
             "items": {
                 "type": "string"
@@ -117,7 +118,7 @@
         "orcidId": {
             "items": {
                 "examples": [
-                    "https://orcid.org/0000-0003-4365-3717"
+                    "https://orcid.org/0000-0002-9079-593X"
                 ],
                 "format": "uri",
                 "pattern": "^https://orcid\\.org/[-X0-9]{9,21}$",

--- a/schema/entities/resource.json
+++ b/schema/entities/resource.json
@@ -93,12 +93,20 @@
             "anyOf": [
                 {
                     "format": "date-time",
-                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+                    "type": "string"
                 },
                 {
                     "format": "date",
-                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$"
+                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
+                    "type": "string"
                 }
+            ],
+            "examples": [
+                "2011",
+                "2019-03",
+                "2014-08-24",
+                "2022-09-30T20:48:35Z"
             ],
             "sameAs": [
                 "http://purl.org/dc/terms/created"
@@ -228,6 +236,9 @@
             "type": "array"
         },
         "meshId": {
+            "examples": [
+                "http://id.nlm.nih.gov/mesh/D001604"
+            ],
             "items": {
                 "format": "uri",
                 "pattern": "^http://id\\.nlm\\.nih\\.gov/mesh/[A-Z0-9]{2,64}$",
@@ -254,12 +265,20 @@
             "anyOf": [
                 {
                     "format": "date-time",
-                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$"
+                    "pattern": "^[1-9]\\d{3}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}Z$",
+                    "type": "string"
                 },
                 {
                     "format": "date",
-                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$"
+                    "pattern": "^\\d{4}(-\\d{2})?(-\\d{2})?$",
+                    "type": "string"
                 }
+            ],
+            "examples": [
+                "2011",
+                "2019-03",
+                "2014-08-24",
+                "2022-09-30T20:48:35Z"
             ],
             "sameAs": [
                 "http://purl.org/dc/terms/modified"
@@ -414,9 +433,9 @@
             ],
             "type": "array"
         },
-        "wasGenereatedBy": {
+        "wasGeneratedBy": {
             "$ref": "/schema/entities/activity#/identifier",
-            "sameAs": "http://www.w3.org/ns/prov#wasGenereatedBy"
+            "sameAs": "http://www.w3.org/ns/prov#wasGeneratedBy"
         }
     },
     "required": [

--- a/schema/entities/variable.json
+++ b/schema/entities/variable.json
@@ -24,7 +24,7 @@
         "dataType": {
             "$ref": "/schema/entities/concept#/identifier",
             "examples": [
-                "https://mex.rki.de/concept/data-type-1"
+                "https://mex.rki.de/item/data-type-1"
             ],
             "subPropertyOf": [
                 "http://purl.org/dc/terms/type"

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+from setuptools import setup
+
+setup(
+    name="mex-model",
+    version="2.1.1",
+    author_email="mex@rki.de",
+    author="RKI MEx Team",
+    description="RKI MEx metadata model",
+    license="MIT",
+    package_dir={"mex.model": "schema"},
+)


### PR DESCRIPTION
- make mex-model installable as a python distribution
- convert `activity.start` and `end` to arrays
- add `useScheme` to `Distribution.license`
- update examples to be inline with mex-common
- fix patterns to JSON-escape `\`
- fix typos