### PR TITLE
Bump cookiecutter template to 77ce51

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "bd0e3bf51cb5d37695911e65fa2ae378d93866d1",
+  "commit": "77ce51f46b0897c6fbd29782c32923075e296c2a",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -89,4 +89,3 @@ jobs:
           git commit --message "Bump cookiecutter template to $template_ref" --verbose
           git push --set-upstream origin cruft/cookiecutter-template-${template_ref} --force --verbose
           gh pr create --title "Bump cookiecutter template to $template_ref" --body-file .cruft-pr-body --label cruft --assignee ${{ vars.MEX_BOT_USER }}
-          exit 1


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/77ce51
