### PR TITLE
Bump cookiecutter template to 20d79c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "6c948ad23a4e80d9861eeac8f522af3fb18e3db8",
+  "commit": "20d79c1e1bde360a5767847f79ad70b683a5d88f",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/.github/workflows/cve-scan.yml
+++ b/.github/workflows/cve-scan.yml
@@ -2,6 +2,8 @@ name: CVE Scan
 
 on:
   push:
+    branches: ["main"]
+    tags: ["**"]
   pull_request:
     types:
       - opened

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -2,6 +2,8 @@ name: Linting
 
 on:
   push:
+    branches: ["main"]
+    tags: ["**"]
   pull_request:
     types:
       - opened


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/20d79c

# Conflicts

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -88,7 +88,7 @@ jobs:
     needs: release
     steps:
       - name: Build, tag and push docker image to ghcr
-        uses: GlueOps/github-actions-build-push-containers@v0.4.4
+        uses: GlueOps/github-actions-build-push-containers@v0.4.5
         with:
           tags: "${{ github.sha }},${{ needs.release.outputs.tag }},latest"
 
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.2.4
+        uses: renovatebot/github-action@v40.2.5
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-model"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -2,4 +2,4 @@ cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
 pdm==2.17.3
 pre-commit==3.8.0
-wheel==0.43.0
+wheel==0.44.0
```
