### PR TITLE
Bump cookiecutter template to cee205

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "a782ed7ea131e6d0cd67d4cc81975f2328228bcd",
+  "commit": "cee205846b2eb6f25e1ce762f395aa50ccbbf93e",
   "checkout": null,
   "context": {
     "cookiecutter": {


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/cee205

# Conflicts

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.2.5
+        uses: renovatebot/github-action@v40.2.7
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-model"
```

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -85,6 +85,7 @@ jobs:
   containerize:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    needs: release
     steps:
       - name: Checkout repo
         uses: actions/checkout@v4
@@ -122,9 +123,9 @@ jobs:
 
       - name: 'Build Inventory Image'
         run: |
-          docker build . 
-          --tag ghcr.io/robert-koch-institut/mex-model:latest
-          --tag ghcr.io/robert-koch-institut/mex-model:${{ github.sha }}
+          docker build . \
+          --tag ghcr.io/robert-koch-institut/mex-model:latest \
+          --tag ghcr.io/robert-koch-institut/mex-model:${{ github.sha }} \
           --tag ghcr.io/robert-koch-institut/mex-model:${{ needs.release.outputs.tag }}
           docker push ghcr.io/robert-koch-institut/mex-model:latest
 
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.17.3
+pdm==2.18.1
 pre-commit==3.8.0
 wheel==0.44.0
```
