### PR TITLE
Bump cookiecutter template to 6c467f

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "fca460e90134ef8c10f54d491aa80891509b1b6c",
+  "commit": "6c467f8809dcc640c3b7aab80e42f3af1f89b1bd",
   "checkout": null,
   "context": {
     "cookiecutter": {

--- a/README.md
+++ b/README.md
@@ -38,13 +38,14 @@ data Findable, Accessible, Interoperable and Reusable.
 **Contact** \
 For more information, please feel free to email us at [mex@rki.de](mailto:mex@rki.de).
 
-### Publisher of this document
+### Publisher
+
 **Robert Koch-Institut** \
 Nordufer 20 \
 13353 Berlin \
 Germany
 
-## package
+## Package
 
 Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1.
 `entities`, described by their properties, 2. `fields`, small objects, that are used as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,48 +46,57 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 ignore = [
-    "D100",   # Allow missing module docstring for brevity
-    "D104",   # Allow missing package docstring for brevity
-    "D106",   # Allow missing nested class docstring (eg pydantic Config)
-    "D203",   # Disallow blank line before class docstring (inverse of D211)
-    "D213",   # Disallow multi-line docstring starting at second line (inverse of D212)
-    "D406",   # Allow section name ending with newline (google style compat)
-    "D407",   # Allow missing dashed underline after section (google style compat)
-    "D413",   # Allow missing blank line after last section (google style compat)
-    "N805",   # Allow first argument of a method to be non-self (pydantic compat)
-    "N815",   # Allow mixedCase variables in class scope (model compat)
-    "RUF012", # Allow mutable class attributes (pydantic compat)
+    "AIR",     # Disable airflow specific rules (we are not using airflow)
+    "ANN",     # Disable all annotations checks (handled by mypy)
+    "COM",     # Disable flake8-commas checks (let ruff format handle that)
+    "CPY",     # Disable copyright notice checks (we have LICENSE files)
+    "D100",    # Allow missing module docstring (for brevity and speed)
+    "D104",    # Allow missing package docstring (for brevity and speed)
+    "D203",    # Disallow blank line before class docstring (inverse of D211)
+    "D213",    # Disallow multi-line docstring starting at second line (inverse of D212)
+    "D406",    # Allow section name ending with newline (google style compat)
+    "D407",    # Allow missing dashed underline after section (google style compat)
+    "D413",    # Allow missing blank line after last section (google style compat)
+    "DJ",      # Disable django specific checks (we are not using django)
+    "FBT",     # Disable boolean type hint checks (for more flexibility)
+    "FIX",     # Allow committing with open TODOs (don't punish committers)
+    "ISC001",  # Disable checks for implicitly concatenated strings (formatter compat)
+    "N805",    # Allow first argument of a method to be non-self (pydantic compat)
+    "N815",    # Allow mixedCase variables in class scope (model compat)
+    "PTH123",  # Allow using builtin open method (simpler than pathlib)
+    "RUF012",  # Allow mutable class attributes (pydantic compat)
+    "SIM108",  # Allow explicit if-else instead of ternary (easier to read)
+    "TD003",   # Allow TODOs without ticket link (don't punish TODO writers)
+    "TRY003",  # Allow long exception message at the raise site (for pydantic)
 ]
-select = [
-    "A",    # Flake8 builtin shaddow
-    "B",    # BugBear bug and issue finder
-    "C90",  # McCabe complexity checker
-    "D",    # Python docstring style checker
-    "E",    # Python code style errors
-    "ERA",  # Commented-out code detector
-    "F",    # Pyflakes passive python checker
-    "I",    # Isort import utility
-    "N",    # Pep8 naming conventions
-    "PERF", # Lint performance anti-patterns
-    "RET",  # Flake8 return statement checker
-    "RUF",  # Ruff-specific rules
-    "S",    # Bandit automated security testing
-    "T10",  # Flake8 debug statement checker
-    "T20",  # Flake8 print statement checker
-    "UP",   # PyUpgrade syntax recommender
-    "W",    # Python code style warnings
-]
+select = ["ALL"]
 
 [tool.ruff.lint.per-file-ignores]
-"tests/**" = [
-    "D101", # Allow missing docstring in public class for tests
-    "D102", # Allow missing docstring in public method for tests
-    "D103", # Allow missing docstring in public function for tests
-    "D107", # Allow missing docstring in `__init__` for tests
-    "E501", # Allow line too long in tests
-    "N807", # Allow mocking `__init__` for tests
-    "S101", # Allow use of `assert` in tests
+"docs/**" = [
+    "INP001",   # Docs folder does not need to be a package
 ]
+"scripts/**" = [
+    "INP001",   # Scripts folder does not need to be a package
+]
+"tests/**" = [
+    "ARG005",   # Allow unused lambda arguments for mocking
+    "D101",     # Allow missing docstring in public class
+    "D102",     # Allow missing docstring in public method
+    "D103",     # Allow missing docstring in public function
+    "D107",     # Allow missing docstring in `__init__`
+    "E501",     # Allow longer lines with test data
+    "ISC",      # Allow implicitly concatenated strings
+    "N807",     # Allow mocking `__init__`
+    "PLR0915",  # Allow functions with many statements
+    "PLR2004",  # Allow comparing with static values
+    "PT004",    # Allow public fixtures without returns
+    "PT013",    # Allow more flexible pytest imports
+    "S101",     # Allow use of `assert` in tests
+    "SLF",      # Allow private member access
+]
+
+[tool.ruff.lint.flake8-import-conventions.extend-aliases]
+"reflex" = "rx"
 
 [tool.ruff.lint.isort]
 known-first-party = ["mex", "tests"]


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/6c467f

# Conflicts

```diff a/README.md b/README.md	(rejected hunks)
@@ -9,7 +9,7 @@ JSON schema files defining the MEx metadata model.
 [![open-code](https://github.com/robert-koch-institut/mex-model/actions/workflows/open-code.yml/badge.svg)](https://gitlab.opencode.de/robert-koch-institut/mex/mex-model)
 [![testing](https://github.com/robert-koch-institut/mex-model/actions/workflows/testing.yml/badge.svg)](https://github.com/robert-koch-institut/mex-model/actions/workflows/testing.yml)
 
-## project
+## Project
 
 The Metadata Exchange (MEx) project is committed to improve the retrieval of RKI
 research data and projects. How? By focusing on metadata: instead of providing the
@@ -55,14 +56,14 @@ translations of the properties and are to be used in the context of user interfa
 5. `vocabularies`, which are used in context of the `entities`. A more detailed
 description of the model's context can be found in `/docs/index.md`.
 
-## license
+## License
 
 This package is licensed under the [MIT license](/LICENSE). All other software
 components of the MEx project are open-sourced under the same license as well.
 
-## development
+## Development
 
-### installation
+### Installation
 
 - on unix, consider using pyenv https://github.com/pyenv/pyenv
   - get pyenv `curl https://pyenv.run | bash`
@@ -75,13 +76,13 @@ components of the MEx project are open-sourced under the same license as well.
   - switch version `pyenv global 3.11`
   - run `.\mex.bat install`
 
-### linting and testing
+### Linting and testing
 
 - run all linters with `pdm lint`
 - run only unit tests with `pdm unit`
 - run unit and integration tests with `pdm test`
 
-### updating dependencies
+### Updating dependencies
 
 - update boilerplate files with `cruft update`
 - update global requirements in `requirements.txt` manually
@@ -89,18 +90,18 @@ components of the MEx project are open-sourced under the same license as well.
 - update package dependencies using `pdm update-all`
 - update github actions in `.github/workflows/*.yml` manually
 
-### creating release
+### Creating release
 
 - run `pdm release RULE` to release a new version where RULE determines which part of
   the version to update and is one of `major`, `minor`, `patch`.
 
-### container workflow
+### Container workflow
 
 - build image with `make image`
 - run directly using docker `make run`
 - start with docker compose `make start`
 
-## commands
+## Commands
 
 - run `pdm run {command} --help` to print instructions
 - run `pdm run {command} --debug` for interactive debugging
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,5 @@
 cruft==2.15.0
-mex-release @ git+https://github.com/robert-koch-institut/mex-release.git
-pdm==2.19.1
+mex-release==0.2.0
+pdm==2.19.3
 pre-commit==4.0.1
 wheel==0.44.0
```

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v40.3.1
+        uses: renovatebot/github-action@v40.3.4
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-model"
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -9,14 +9,14 @@ urls = { Repository = "https://github.com/robert-koch-institut/mex-model" }
 requires-python = ">=3.11,<3.13"
 dependencies = []
 optional-dependencies.dev = [
-    "ipdb>=0.13.13,<1",
-    "mypy>=1.11.2,<2",
-    "pytest-cov>=5.0.0,<6",
-    "pytest-random-order>=1.1.1,<2",
-    "pytest-xdist>=3.6.1,<4",
-    "pytest>=8.3.3,<9",
-    "ruff>=0.6.5,<1",
-    "sphinx>=8.0.2,<9",
+    "ipdb>=0.13,<1",
+    "mypy>=1,<2",
+    "pytest-cov>=5,<6",
+    "pytest-random-order>=1,<2",
+    "pytest-xdist>=3,<4",
+    "pytest>=8,<9",
+    "ruff>=0.6,<1",
+    "sphinx>=8,<9",
 ]
 
 [project.scripts]
```
