### PR TITLE
Bump cookiecutter template to b0a205

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "2dfb12b902ff9c7381e768ed1e57a4b338a94ae4",
+  "commit": "b0a2056a104f39cd18e6b395a27d18473caa73d7",
   "checkout": null,
   "context": {
     "cookiecutter": {


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/b0a205

# Conflicts

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,5 @@
 cruft==2.15.0
 mex-release==0.3.0
-pdm==2.19.3
+pdm==2.20.0.post1
 pre-commit==4.0.1
 wheel==0.44.0
```

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -59,6 +59,8 @@ jobs:
 
       - name: Configure git
         env:
+          MEX_BOT_EMAIL: ${{ vars.MEX_BOT_EMAIL }}
+          MEX_BOT_USER: ${{ vars.MEX_BOT_USER }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
         run: |
```

```diff a/.github/workflows/cookiecutter.yml b/.github/workflows/cookiecutter.yml	(rejected hunks)
@@ -48,6 +48,8 @@ jobs:
 
       - name: Configure git
         env:
+          MEX_BOT_EMAIL: ${{ vars.MEX_BOT_EMAIL }}
+          MEX_BOT_USER: ${{ vars.MEX_BOT_USER }}
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
           SIGNING_PUB: ${{ secrets.SIGNING_PUB }}
         run: |
```
