### PR TITLE
changed the type of the title field in distribution to be a text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changes
 
+- type of Distribution.title is now a Text array field, instead of single string
+
 ### Deprecated
 
 ### Removed
@@ -20,6 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Security
 
 ## [3.3.2] - 2024-11-19
+
+### Fixed
+
+- fixed sidebar links in sphinx docs
 
 ## [3.3.1] - 2024-11-19
 

--- a/mex/model/entities/distribution.json
+++ b/mex/model/entities/distribution.json
@@ -215,14 +215,14 @@
         },
         "title": {
             "description": "The name of the distribution.",
-            "examples": [
-                "theNameOfTheFile"
-            ],
-            "minLength": 1,
+            "items": {
+                "$ref": "/schema/fields/text"
+            },
+            "minItems": 1,
             "sameAs": [
                 "http://purl.org/dc/terms/title"
             ],
-            "type": "string"
+            "type": "array"
         }
     },
     "required": [


### PR DESCRIPTION
# PR Context
We want to make all fields that have the name "title" of type text field.

# Changes
type of field title in distribution, now it is a text field.
