### PR TITLE
Bump cookiecutter template to 57e9b7

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,13 +1,14 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "a4f25ab84f9e485ad77eb03663a9cf486f7a5826",
+  "commit": "57e9b752fed460f5542bda226467210d0135f4fb",
   "checkout": null,
   "context": {
     "cookiecutter": {
       "project_name": "model",
       "short_summary": "JSON schema files defining the MEx metadata model.",
       "long_summary": "Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1. `entities`, described by their properties, 2. `fields`, small objects, that are used as `$ref` for certain properties, 3. an `extension`, which contains additional properties, that are not in scope of the JSON schema definition, 4. `i18n` files, that hold translations of the properties and are to be used in the context of user interfaces and 5. `vocabularies`, which are used in context of the `entities`. A more detailed description of the model's context can be found in `/docs/index.rst`.",
-      "_template": "https://github.com/robert-koch-institut/mex-template"
+      "_template": "https://github.com/robert-koch-institut/mex-template",
+      "_commit": "57e9b752fed460f5542bda226467210d0135f4fb"
     }
   },
   "directory": null

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -13,8 +13,10 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 jobs:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,8 +8,10 @@ on:
   workflow_dispatch:
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 permissions:

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,8 +12,10 @@ on:
   workflow_dispatch:
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 concurrency:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,8 +15,10 @@ on:
         required: true
 
 env:
-  PIP_NO_OPTION: on
+  PDM_CHECK_UPDATE: False
+  PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
+  PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
 
 permissions:
@@ -84,6 +86,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          ref: ${{ needs.release.outputs.tag }}
 
       - name: Cache requirements
         uses: actions/cache@v4
@@ -106,7 +109,6 @@ jobs:
       - name: Build wheel and sdist distros and create a github release
         env:
           GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
-          PDM_CHECK_UPDATE: False
         run: |
           gh release create ${{ needs.release.outputs.tag }} --generate-notes --latest --verify-tag
           pdm build --dest dist

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.7.3
+    rev: v0.9.1
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.20.1
+    rev: 2.22.2
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2024 Robert Koch-Institut
+Copyright (c) 2025 Robert Koch-Institut
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/57e9b7

# Conflicts

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v41.0.2
+        uses: renovatebot/github-action@v41.0.8
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-model"
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -15,7 +15,7 @@ optional-dependencies.dev = [
     "pytest-random-order>=1,<2",
     "pytest-xdist>=3,<4",
     "pytest>=8,<9",
-    "ruff>=0.7,<1",
+    "ruff>=0.9,<1",
     "sphinx>=8,<9",
 ]
 
@@ -138,5 +138,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.4.1"]
+requires = ["pdm-backend==2.4.3"]
 build-backend = "pdm.backend"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,5 +1,4 @@
-cruft==2.15.0
+cruft==2.16.0
 mex-release==0.3.0
-pdm==2.20.1
+pdm==2.22.1
 pre-commit==4.0.1
-wheel==0.45.0
```
