### PR TITLE
Bump cookiecutter template to 5446da

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "57e9b752fed460f5542bda226467210d0135f4fb",
+  "commit": "5446dae8486bd2412e75f97790c6bd800fa26a34",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "JSON schema files defining the MEx metadata model.",
       "long_summary": "Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1. `entities`, described by their properties, 2. `fields`, small objects, that are used as `$ref` for certain properties, 3. an `extension`, which contains additional properties, that are not in scope of the JSON schema definition, 4. `i18n` files, that hold translations of the properties and are to be used in the context of user interfaces and 5. `vocabularies`, which are used in context of the `entities`. A more detailed description of the model's context can be found in `/docs/index.rst`.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "57e9b752fed460f5542bda226467210d0135f4fb"
+      "_commit": "5446dae8486bd2412e75f97790c6bd800fa26a34"
     }
   },
   "directory": null

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,20 +1,20 @@
-# PR Context
+### PR Context
 <!-- Additional info for the reviewer -->
 
-# Added
+### Added
 <!-- New features and interfaces -->
 
-# Changes
+### Changes
 <!-- Changes in existing functionality -->
 
-# Deprecated
+### Deprecated
 <!-- Soon-to-be removed features -->
 
-# Removed
+### Removed
 <!-- Definitely removed features -->
 
-# Fixed
+### Fixed
 <!-- Fixed bugs -->
 
-# Security
+### Security
 <!-- Fixed vulnerabilities -->

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ available to external researchers as well as the interested (professional) publi
 find research data from the RKI.
 
 For further details, please consult our
-[project page](https://www.rki.de/DE/Content/Forsch/MEx/MEx_node.html).
+[project page](https://www.rki.de/DE/Aktuelles/Publikationen/Forschungsdaten/MEx/metadata-exchange-plattform-mex-node.html).
 
 [^1]: FAIR is referencing the so-called
 [FAIR data principles](https://www.go-fair.org/fair-principles/) – guidelines to make


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/5446da
