### PR TITLE
expand_pattern_for_DOI_URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- expand the pattern for DOI Urls as these can also contain lowercase letters.
+
 ### Security
 
 ## [3.5.1] - 2025-01-29

--- a/mex/model/entities/bibliographic-resource.json
+++ b/mex/model/entities/bibliographic-resource.json
@@ -103,7 +103,7 @@
                         "http://dx.doi.org/10.25646/5147",
                         "https://doi.org/10.1016/j.vaccine.2022.11.065"
                     ],
-                    "pattern": "^(((http)|(https))://(dx.)?doi.org/)(10.\\d{4,9}/[-._;()/:A-Z0-9]+)$",
+                    "pattern": "^(((http)|(https))://(dx.)?doi.org/)(10.\\d{4,9}/[-._;()/:A-Za-z0-9]+)$",
                     "type": "string"
                 },
                 {

--- a/mex/model/entities/resource.json
+++ b/mex/model/entities/resource.json
@@ -224,7 +224,7 @@
                         "http://dx.doi.org/10.25646/5147",
                         "https://doi.org/10.1016/j.vaccine.2022.11.065"
                     ],
-                    "pattern": "^(((http)|(https))://(dx.)?doi.org/)(10.\\d{4,9}/[-._;()/:A-Z0-9]+)$",
+                    "pattern": "^(((http)|(https))://(dx.)?doi.org/)(10.\\d{4,9}/[-._;()/:A-Za-z0-9]+)$",
                     "type": "string"
                 },
                 {


### PR DESCRIPTION


### Fixed
- expand the pattern for DOI Urls as these can also contain lowercase letters.
