### PR TITLE
Bump cookiecutter template to 8bdad0

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "5446dae8486bd2412e75f97790c6bd800fa26a34",
+  "commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "JSON schema files defining the MEx metadata model.",
       "long_summary": "Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1. `entities`, described by their properties, 2. `fields`, small objects, that are used as `$ref` for certain properties, 3. an `extension`, which contains additional properties, that are not in scope of the JSON schema definition, 4. `i18n` files, that hold translations of the properties and are to be used in the context of user interfaces and 5. `vocabularies`, which are used in context of the `entities`. A more detailed description of the model's context can be found in `/docs/index.rst`.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "5446dae8486bd2412e75f97790c6bd800fa26a34"
+      "_commit": "8bdad06a5eca52607f046b75cb0cdd9d7ab4912e"
     }
   },
   "directory": null

--- a/.gitignore
+++ b/.gitignore
@@ -121,6 +121,11 @@ dmypy.json
 # SQLite databases
 *.db
 
+# Reflex
+.states
+assets/external/
+.web
+
 # Default exports
 *.ndjson
 data/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.9.1
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [--fix, --exit-non-zero-on-fix]
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.22.2
+    rev: 2.22.3
     hooks:
       - id: pdm-lock-check
         name: pdm


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/8bdad0
