### PR TITLE
Bump cookiecutter template to ed5deb

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "08b84c365a20d24ca04369a70495034491e0a401",
+  "commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "JSON schema files defining the MEx metadata model.",
       "long_summary": "Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1. `entities`, described by their properties, 2. `fields`, small objects, that are used as `$ref` for certain properties, 3. an `extension`, which contains additional properties, that are not in scope of the JSON schema definition, 4. `i18n` files, that hold translations of the properties and are to be used in the context of user interfaces and 5. `vocabularies`, which are used in context of the `entities`. A more detailed description of the model's context can be found in `/docs/index.rst`.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "08b84c365a20d24ca04369a70495034491e0a401"
+      "_commit": "ed5deb106b3d34aa758dcd4f4d3628a1ffb2b159"
     }
   },
   "directory": null

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -18,6 +18,7 @@ env:
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
+  PY_COLORS: "1"
 
 jobs:
   cruft:

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -13,6 +13,7 @@ env:
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
+  PY_COLORS: "1"
 
 permissions:
   contents: read

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -17,6 +17,7 @@ env:
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
+  PY_COLORS: "1"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,7 @@ env:
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on
   PIP_PREFER_BINARY: on
+  PY_COLORS: "1"
 
 permissions:
   contents: write

--- a/.gitignore
+++ b/.gitignore
@@ -122,19 +122,18 @@ dmypy.json
 # SQLite databases
 *.db
 
-# Reflex
-.states
-assets/external/
-.web
-
 # MEx specific
 .aws/
 .invenio.private
+.states
+.web
 *.ndjson
+assets/external/
 data/
 identity.csv
 logs/
 payload
 schema.json
+storage/
 tmp*/
 work/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ templates_path = ["."]
 # see https://sphinx-jsonschema.readthedocs.io/en/latest/extensions.html
 
 
-def _patched_sphinx_jsonschema_simpletype(self, schema):
+def _patched_sphinx_jsonschema_simpletype(self, schema):  # noqa: ANN001, ANN202
     """Render the `useScheme` schema properties for every vocabulary type."""
     rows = _original_sphinx_jsonschema_simpletype(self, schema)
     if "useScheme" in schema:
@@ -49,7 +49,7 @@ def _patched_sphinx_jsonschema_simpletype(self, schema):
     return rows
 
 
-def _patched_sphinx_jsonschema_kvpairs(self, schema, keys):
+def _patched_sphinx_jsonschema_kvpairs(self, schema, keys):  # noqa: ANN001, ANN202
     """Render `default` and `pattern` schema properties as inline code-blocks."""
     for k in keys:
         if k in schema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,24 +50,19 @@ docstring-code-format = true
 
 [tool.ruff.lint]
 ignore = [
-    "AIR",     # Disable airflow specific rules (we are not using airflow)
-    "ANN",     # Disable all annotations checks (handled by mypy)
     "COM",     # Disable flake8-commas checks (let ruff format handle that)
     "CPY",     # Disable copyright notice checks (we have LICENSE files)
-    "D100",    # Allow missing module docstring (for brevity and speed)
-    "D104",    # Allow missing package docstring (for brevity and speed)
+    "D100",    # Allow missing module docstring (for brevity)
+    "D104",    # Allow missing package docstring (for brevity)
     "D203",    # Disallow blank line before class docstring (inverse of D211)
     "D213",    # Disallow multi-line docstring starting at second line (inverse of D212)
     "D406",    # Allow section name ending with newline (google style compat)
     "D407",    # Allow missing dashed underline after section (google style compat)
     "D413",    # Allow missing blank line after last section (google style compat)
-    "DJ",      # Disable django specific checks (we are not using django)
-    "FBT",     # Disable boolean type hint checks (for more flexibility)
     "FIX",     # Allow committing with open TODOs (don't punish committers)
     "ISC001",  # Disable checks for implicitly concatenated strings (formatter compat)
     "N805",    # Allow first argument of a method to be non-self (pydantic compat)
     "N815",    # Allow mixedCase variables in class scope (model compat)
-    "PTH123",  # Allow using builtin open method (simpler than pathlib)
     "RUF012",  # Allow mutable class attributes (pydantic compat)
     "SIM108",  # Allow explicit if-else instead of ternary (easier to read)
     "TD003",   # Allow TODOs without ticket link (don't punish TODO writers)
@@ -90,7 +85,6 @@ select = ["ALL"]
     "D103",     # Allow missing docstring in public function
     "D107",     # Allow missing docstring in `__init__`
     "E501",     # Allow longer lines with test data
-    "ISC",      # Allow implicitly concatenated strings
     "N807",     # Allow mocking `__init__`
     "PLR0915",  # Allow functions with many statements
     "PLR2004",  # Allow comparing with static values


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/ed5deb

