### PR TITLE
Feature/mx 1878 fix some stuff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Two new properties to mex:Resource: provenance and hasPurpose
+
 ### Changes
+
+- BREAKING: changed URI of wikidataId
+- BREAKING: repositoryURL (mex:BibliographicResource) is now an array
 
 ### Deprecated
 
 ### Removed
+
+- BREAKING: Deleted consent type "Implied Consent" because of the regulations from
+  Data Protection Officer.
 
 ### Fixed
 

--- a/mex/model/entities/bibliographic-resource.json
+++ b/mex/model/entities/bibliographic-resource.json
@@ -383,16 +383,19 @@
             "type": "array"
         },
         "repositoryURL": {
-            "anyOf": [
-                {
-                    "$ref": "/schema/fields/link"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
-            "description": "The handle of the publication in the repository, where the publication is stored."
+            "default": [],
+            "description": "The handle of the publication in the repository, where the publication is stored.",
+            "items": {
+                "anyOf": [
+                    {
+                        "$ref": "/schema/fields/link"
+                    },
+                    {
+                        "type": "null"
+                    }
+                ]
+            },
+            "type": "array"
         },
         "section": {
             "anyOf": [

--- a/mex/model/entities/consent.json
+++ b/mex/model/entities/consent.json
@@ -30,7 +30,7 @@
                 {
                     "$ref": "/schema/entities/concept#/identifier",
                     "examples": [
-                        "https://mex.rki.de/item/consent-type-1"
+                        "https://mex.rki.de/item/consent-type-2"
                     ],
                     "useScheme": "https://mex.rki.de/item/consent-type"
                 },

--- a/mex/model/entities/organization.json
+++ b/mex/model/entities/organization.json
@@ -161,12 +161,12 @@
             "description": "Identifier from Wikidata.",
             "items": {
                 "examples": [
-                    "https://www.wikidata.org/entity/Q679041",
-                    "https://www.wikidata.org/entity/Q918501",
-                    "https://www.wikidata.org/entity/Q491566"
+                    "http://www.wikidata.org/entity/Q679041",
+                    "http://www.wikidata.org/entity/Q918501",
+                    "http://www.wikidata.org/entity/Q491566"
                 ],
                 "format": "uri",
-                "pattern": "^https://www\\.wikidata\\.org/entity/[PQ0-9]{2,64}$",
+                "pattern": "^http://www\\.wikidata\\.org/entity/[PQ0-9]{2,64}$",
                 "type": "string"
             },
             "type": "array"

--- a/mex/model/entities/resource.json
+++ b/mex/model/entities/resource.json
@@ -282,6 +282,18 @@
                 "https://w3id.org/dpv#hasPersonalData"
             ]
         },
+        "hasPurpose": {
+            "$comment": "Source: Draft of HealthDCAT-AP published on 31st Jan 2024 (Milestone M6.2 Technical working group on the transition from existing metadata templates to HealthDCAT-AP).",
+            "default": [],
+            "description": "A free text statement of the purpose of the processing of data or personal data.",
+            "items": {
+                "$ref": "/schema/fields/text"
+            },
+            "sameAs": [
+                "https://w3id.org/dpv#hasPurpose"
+            ],
+            "type": "array"
+        },
         "icd10code": {
             "default": [],
             "description": "A concept from ICD-10.",
@@ -508,6 +520,18 @@
             "items": {
                 "$ref": "/schema/fields/text"
             },
+            "type": "array"
+        },
+        "provenance": {
+            "$comment": "Source: Draft of HealthDCAT-AP published on 31st Jan 2024 (Milestone M6.2 Technical working group on the transition from existing metadata templates to HealthDCAT-AP).",
+            "default": [],
+            "description": "A statement about the lineage of a Dataset. Information about how the data was collected, including methodologies, tools, and protocols used.",
+            "items": {
+                "$ref": "/schema/fields/text"
+            },
+            "sameAs": [
+                "http://purl.org/dc/terms/provenance"
+            ],
             "type": "array"
         },
         "publication": {

--- a/mex/model/vocabularies/consent-type.json
+++ b/mex/model/vocabularies/consent-type.json
@@ -1,25 +1,6 @@
 [
     {
         "definition": {
-            "de": "Einwilligung, die indirekt durch eine Handlung gegebenen wurde, die nicht alleinig mit einer einwilligenden Entscheidung assoziert werden kann.",
-            "en": "Consent that is implied indirectly through an action not associated solely with conveying a consenting decision."
-        },
-        "exactMatch": [
-            "https://w3id.org/dpv#ImpliedConsent"
-        ],
-        "identifier": "https://mex.rki.de/item/consent-type-1",
-        "inScheme": "https://mex.rki.de/item/consent-type",
-        "note": {
-            "de": "Eine Implizierte Einwilligung ist eine Form der Informierten Einwillugung. Ein Beispiel ist der Hinweis über die Aufnahme durch Überwachungskamera in einem überwachte Bereich.",
-            "en": "Implied consent is expected to also be Informed Consent. An example is a CCTV notice outside a monitored area that informs the individuals that by walking in they would be consenting to the use of camera for surveillance."
-        },
-        "prefLabel": {
-            "de": "Implizierte Einwilligung",
-            "en": "Implied Consent"
-        }
-    },
-    {
-        "definition": {
             "de": "Einwilligung, die durch eine explizierte Handlung, einer einwilligenden Entscheidung, erfolgte.",
             "en": "Consent that is expressed through an action intended to convey a consenting decision."
         },


### PR DESCRIPTION
### PR Context
We need to fix some minor issues within the model as well as add two new properties for BMG Erlass and in preparation of EHDS.

### Added
Two new properties to mex:Resource

- provenance
- hasPurpose

### Changes

- changed URI of wikidataId
- repositoryURL (mex:BibliographicResource) is now an array

### Removed
- Deleted consent type "Implied Consent" because of the regulations from Data Protection Officer.

