### PR TITLE
Bump cookiecutter template to 82d72c

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "0eb10763f9de744b839dca9c86e32c5033d3d77a",
+  "commit": "82d72c3719cae04c8057a75f5872faacf24d72a6",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "JSON schema files defining the MEx metadata model.",
       "long_summary": "Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1. `entities`, described by their properties, 2. `fields`, small objects, that are used as `$ref` for certain properties, 3. an `extension`, which contains additional properties, that are not in scope of the JSON schema definition, 4. `i18n` files, that hold translations of the properties and are to be used in the context of user interfaces and 5. `vocabularies`, which are used in context of the `entities`. A more detailed description of the model's context can be found in `/docs/index.rst`.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "0eb10763f9de744b839dca9c86e32c5033d3d77a"
+      "_commit": "82d72c3719cae04c8057a75f5872faacf24d72a6"
     }
   },
   "directory": null

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
+          persist-credentials: false
 
       - name: Cache requirements
         uses: actions/cache@v4
@@ -73,8 +74,6 @@ jobs:
 
       - name: Release new version
         id: release
-        env:
-          GH_TOKEN: ${{ secrets.WORKFLOW_TOKEN }}
         run: |
           pdm release ${{ inputs.version }}
           echo "tag=$(git describe --abbrev=0 --tags)" >> "$GITHUB_OUTPUT"
@@ -94,6 +93,7 @@ jobs:
         with:
           fetch-depth: 1
           ref: ${{ needs.release.outputs.tag }}
+          persist-credentials: false
 
       - name: Cache requirements
         uses: actions/cache@v4


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/82d72c

# Conflicts

```diff a/.github/workflows/release.yml b/.github/workflows/release.yml	(rejected hunks)
@@ -41,6 +41,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 1
+          token: ${{ secrets.WORKFLOW_TOKEN }}
 
       - name: Cache requirements
         uses: actions/cache@v4
```
