### PR TITLE
Bump cookiecutter template to e886ec

### DIFF
--- a/.cruft.json
+++ b/.cruft.json
@@ -1,6 +1,6 @@
 {
   "template": "https://github.com/robert-koch-institut/mex-template",
-  "commit": "82d72c3719cae04c8057a75f5872faacf24d72a6",
+  "commit": "e886ec4a4cddc865dedb40f9ead24530884110a8",
   "checkout": null,
   "context": {
     "cookiecutter": {
@@ -8,7 +8,7 @@
       "short_summary": "JSON schema files defining the MEx metadata model.",
       "long_summary": "Our metadata model is represented as JSON schema in `mex/model`. There, we defined 1. `entities`, described by their properties, 2. `fields`, small objects, that are used as `$ref` for certain properties, 3. an `extension`, which contains additional properties, that are not in scope of the JSON schema definition, 4. `i18n` files, that hold translations of the properties and are to be used in the context of user interfaces and 5. `vocabularies`, which are used in context of the `entities`. A more detailed description of the model's context can be found in `/docs/index.rst`.",
       "_template": "https://github.com/robert-koch-institut/mex-template",
-      "_commit": "82d72c3719cae04c8057a75f5872faacf24d72a6"
+      "_commit": "e886ec4a4cddc865dedb40f9ead24530884110a8"
     }
   },
   "directory": null

--- a/.github/workflows/cookiecutter.yml
+++ b/.github/workflows/cookiecutter.yml
@@ -13,7 +13,6 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  PDM_CHECK_UPDATE: False
   PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -8,7 +8,6 @@ on:
   workflow_dispatch:
 
 env:
-  PDM_CHECK_UPDATE: False
   PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -12,7 +12,6 @@ on:
   workflow_dispatch:
 
 env:
-  PDM_CHECK_UPDATE: False
   PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,6 @@ on:
         required: true
 
 env:
-  PDM_CHECK_UPDATE: False
   PIP_DISABLE_PIP_VERSION_CHECK: on
   PIP_NO_CLEAN: on
   PIP_NO_INPUT: on

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ __pycache__/
 .pdm-build
 .pdm-python
 .Python
+.python-version
 .web/
 *.egg
 *.egg-info/
@@ -91,6 +92,7 @@ celerybeat.pid
 # Environments
 *.env
 .env
+.env.tests
 .venv
 env/
 venv/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,9 +3,9 @@ default_language_version:
   python: python3.11
 repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.9
+    rev: v0.12.4
     hooks:
-      - id: ruff
+      - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]
       - id: ruff-format
   - repo: https://github.com/pre-commit/pre-commit-hooks
@@ -25,7 +25,7 @@ repos:
       - id: fix-byte-order-marker
         name: byte-order
   - repo: https://github.com/pdm-project/pdm
-    rev: 2.24.1
+    rev: 2.25.4
     hooks:
       - id: pdm-lock-check
         name: pdm

--- a/renovate.json
+++ b/renovate.json
@@ -38,5 +38,6 @@
             ],
             "minimumReleaseAge": "7 days"
         }
-    ]
+    ],
+    "prFooter": ""
 }


### PR DESCRIPTION
# Changes

- bumped cookiecutter template to https://github.com/robert-koch-institut/mex-template/commit/e886ec

# Conflicts

```diff a/.github/workflows/renovatebot.yml b/.github/workflows/renovatebot.yml	(rejected hunks)
@@ -22,7 +22,7 @@ jobs:
           fetch-depth: 1
 
       - name: Run renovatebot
-        uses: renovatebot/github-action@v42.0.5
+        uses: renovatebot/github-action@v43.0.3
         env:
           RENOVATE_GIT_PRIVATE_KEY: ${{ secrets.GPG_SIGNING_KEY }}
           RENOVATE_REPOSITORIES: "robert-koch-institut/mex-model"
```

```diff a/requirements.txt b/requirements.txt	(rejected hunks)
@@ -1,4 +1,4 @@
 cruft==2.16.0
 mex-release==0.3.3
-pdm==2.25.2
+pdm==2.25.4
 pre-commit==4.2.0
```

```diff a/pyproject.toml b/pyproject.toml	(rejected hunks)
@@ -15,7 +15,7 @@ optional-dependencies.dev = [
     "pytest-random-order>=1",
     "pytest-xdist>=3",
     "pytest>=8",
-    "ruff>=0.11",
+    "ruff>=0.12",
     "sphinx>=8",
 ]
 
@@ -47,7 +47,7 @@ apidoc = { cmd = "pdm run sphinx-apidoc -f -o docs/source mex" }
 sphinx = { cmd = "pdm run sphinx-build -aE -b dirhtml docs docs/dist" }
 doc = { composite = ["apidoc", "sphinx"] }
 wheel = { cmd = "pdm build --no-sdist" }
-mypy-daemon = { cmd = "pdm run dmypy run --timeout 7200 -- mex" }
+mypy-daemon = { cmd = "pdm run dmypy run --timeout 7200 -- mex tests" }
 lint = { cmd = "pre-commit run --all-files" }
 unit = { cmd = "pdm run pytest -m 'not integration'" }
 test = { cmd = "pdm run pytest --numprocesses=auto --dist=worksteal" }
@@ -132,5 +132,5 @@ known-first-party = ["mex", "tests"]
 convention = "google"
 
 [build-system]
-requires = ["pdm-backend==2.4.4"]
+requires = ["pdm-backend==2.4.5"]
 build-backend = "pdm.backend"
```
