### PR TITLE
change start and end to be of type  array in extracted- and merged-resource.json , adapt changelog accordingly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changes
 
 - updated template to https://github.com/robert-koch-institut/mex-template/commit/192830
+- change propertes `start` and `end` in extracted-resource.json and merged-resource.json to be of type `array` and align them to `Activity.start`and `Activity.end`.
 
 ### Deprecated
 

--- a/mex/model/entities/extracted-resource.json
+++ b/mex/model/entities/extracted-resource.json
@@ -247,48 +247,48 @@
             "description": "The Digital Object Identifier (DOI) of the resource."
         },
         "end": {
-            "anyOf": [
-                {
-                    "$comment": "year_month_day_time",
-                    "examples": [
-                        "2022-09-30T20:48:35Z"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month_day",
-                    "examples": [
-                        "2014-08-24"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month",
-                    "examples": [
-                        "2019-03"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year",
-                    "examples": [
-                        "2024"
-                    ],
-                    "pattern": "^[0-9]{4}$",
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
+            "default": [],
             "description": "End date of the temporal coverage of the resource.",
+            "items": {
+                "anyOf": [
+                    {
+                        "$comment": "year_month_day_time",
+                        "examples": [
+                            "2022-09-30T20:48:35Z"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month_day",
+                        "examples": [
+                            "2014-08-24"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month",
+                        "examples": [
+                            "2019-03"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year",
+                        "examples": [
+                            "2024"
+                        ],
+                        "pattern": "^[0-9]{4}$",
+                        "type": "string"
+                    }
+                ]
+            },
             "sameAs": [
-                "http://www.w3.org/ns/dcat#endDate"
-            ]
+                "http://www.w3.org/ns/dcat#startDate"
+            ],
+            "type": "array"
         },
         "externalPartner": {
             "default": [],
@@ -791,48 +791,48 @@
             "readOnly": true
         },
         "start": {
-            "anyOf": [
-                {
-                    "$comment": "year_month_day_time",
-                    "examples": [
-                        "2022-09-30T20:48:35Z"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month_day",
-                    "examples": [
-                        "2014-08-24"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month",
-                    "examples": [
-                        "2019-03"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year",
-                    "examples": [
-                        "2024"
-                    ],
-                    "pattern": "^[0-9]{4}$",
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
+            "default": [],
             "description": "Start date of the temporal coverage of the resource.",
+            "items": {
+                "anyOf": [
+                    {
+                        "$comment": "year_month_day_time",
+                        "examples": [
+                            "2022-09-30T20:48:35Z"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month_day",
+                        "examples": [
+                            "2014-08-24"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month",
+                        "examples": [
+                            "2019-03"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year",
+                        "examples": [
+                            "2024"
+                        ],
+                        "pattern": "^[0-9]{4}$",
+                        "type": "string"
+                    }
+                ]
+            },
             "sameAs": [
                 "http://www.w3.org/ns/dcat#startDate"
-            ]
+            ],
+            "type": "array"
         },
         "stateOfDataProcessing": {
             "default": [],

--- a/mex/model/entities/extracted-resource.json
+++ b/mex/model/entities/extracted-resource.json
@@ -286,7 +286,7 @@
                 ]
             },
             "sameAs": [
-                "http://www.w3.org/ns/dcat#startDate"
+                "http://www.w3.org/ns/dcat#endDate"
             ],
             "type": "array"
         },

--- a/mex/model/entities/merged-resource.json
+++ b/mex/model/entities/merged-resource.json
@@ -286,7 +286,7 @@
                 ]
             },
             "sameAs": [
-                "http://www.w3.org/ns/dcat#startDate"
+                "http://www.w3.org/ns/dcat#endDate"
             ],
             "type": "array"
         },

--- a/mex/model/entities/merged-resource.json
+++ b/mex/model/entities/merged-resource.json
@@ -247,48 +247,48 @@
             "description": "The Digital Object Identifier (DOI) of the resource."
         },
         "end": {
-            "anyOf": [
-                {
-                    "$comment": "year_month_day_time",
-                    "examples": [
-                        "2022-09-30T20:48:35Z"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month_day",
-                    "examples": [
-                        "2014-08-24"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month",
-                    "examples": [
-                        "2019-03"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year",
-                    "examples": [
-                        "2024"
-                    ],
-                    "pattern": "^[0-9]{4}$",
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
+            "default": [],
             "description": "End date of the temporal coverage of the resource.",
+            "items": {
+                "anyOf": [
+                    {
+                        "$comment": "year_month_day_time",
+                        "examples": [
+                            "2022-09-30T20:48:35Z"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month_day",
+                        "examples": [
+                            "2014-08-24"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month",
+                        "examples": [
+                            "2019-03"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year",
+                        "examples": [
+                            "2024"
+                        ],
+                        "pattern": "^[0-9]{4}$",
+                        "type": "string"
+                    }
+                ]
+            },
             "sameAs": [
-                "http://www.w3.org/ns/dcat#endDate"
-            ]
+                "http://www.w3.org/ns/dcat#startDate"
+            ],
+            "type": "array"
         },
         "externalPartner": {
             "default": [],
@@ -767,48 +767,48 @@
             "type": "array"
         },
         "start": {
-            "anyOf": [
-                {
-                    "$comment": "year_month_day_time",
-                    "examples": [
-                        "2022-09-30T20:48:35Z"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month_day",
-                    "examples": [
-                        "2014-08-24"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year_month",
-                    "examples": [
-                        "2019-03"
-                    ],
-                    "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
-                    "type": "string"
-                },
-                {
-                    "$comment": "year",
-                    "examples": [
-                        "2024"
-                    ],
-                    "pattern": "^[0-9]{4}$",
-                    "type": "string"
-                },
-                {
-                    "type": "null"
-                }
-            ],
-            "default": null,
+            "default": [],
             "description": "Start date of the temporal coverage of the resource.",
+            "items": {
+                "anyOf": [
+                    {
+                        "$comment": "year_month_day_time",
+                        "examples": [
+                            "2022-09-30T20:48:35Z"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])T(?:[0-1][0-9]|2[0-3]):[0-5][0-9]:[0-5][0-9]Z$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month_day",
+                        "examples": [
+                            "2014-08-24"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])-(?:0[1-9]|[12][0-9]|3[01])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year_month",
+                        "examples": [
+                            "2019-03"
+                        ],
+                        "pattern": "^[0-9]{4}-(?:0[1-9]|1[0-2])$",
+                        "type": "string"
+                    },
+                    {
+                        "$comment": "year",
+                        "examples": [
+                            "2024"
+                        ],
+                        "pattern": "^[0-9]{4}$",
+                        "type": "string"
+                    }
+                ]
+            },
             "sameAs": [
                 "http://www.w3.org/ns/dcat#startDate"
-            ]
+            ],
+            "type": "array"
         },
         "stateOfDataProcessing": {
             "default": [],


### PR DESCRIPTION
### PR Context
Requested change by [issue #235 in mex-invenio](https://github.com/robert-koch-institut/mex-invenio/issues/235#issuecomment-4969020546). Properties `Resource.start` and `Resource.end` need to be aligned with `Activity.start` and `Activity.end`. All properties must be of type `array`.

### Changes
change start and end to be of type  array in extracted- and merged-resource.json, adapt changelog accordingly
