### PR TITLE
hotfix/technical-accessibility-typo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- fix typo in the technical accessibility concept scheme identifier:
+  `https://mex.rki.de/item/technical-accessbility` is now
+  `https://mex.rki.de/item/technical-accessibility`
+
 ### Security
 
 ## [5.1.0] - 2026-08-11

--- a/mex/model/vocabularies/concept-schemes.json
+++ b/mex/model/vocabularies/concept-schemes.json
@@ -101,7 +101,7 @@
         "label": "General resource type vocabulary"
     },
     {
-        "identifier": "https://mex.rki.de/item/technical-accessbility",
+        "identifier": "https://mex.rki.de/item/technical-accessibility",
         "label": "Technical accessibility vocabulary"
     },
     {

--- a/mex/model/vocabularies/technical-accessibility.json
+++ b/mex/model/vocabularies/technical-accessibility.json
@@ -5,7 +5,7 @@
             "en": "Platform only accessible within RKI network."
         },
         "identifier": "https://mex.rki.de/item/technical-accessibility-1",
-        "inScheme": "https://mex.rki.de/item/technical-accessbility",
+        "inScheme": "https://mex.rki.de/item/technical-accessibility",
         "prefLabel": {
             "de": "intern",
             "en": "internal"
@@ -17,7 +17,7 @@
             "en": "Openly accessible platform."
         },
         "identifier": "https://mex.rki.de/item/technical-accessibility-2",
-        "inScheme": "https://mex.rki.de/item/technical-accessbility",
+        "inScheme": "https://mex.rki.de/item/technical-accessibility",
         "prefLabel": {
             "de": "extern",
             "en": "external"


### PR DESCRIPTION
### Fixed
 
- fix typo in the technical accessibility concept scheme identifier:
  `https://mex.rki.de/item/technical-accessbility` is now
  `https://mex.rki.de/item/technical-accessibility`
